### PR TITLE
Add rewind before read token from TmpStorage

### DIFF
--- a/lib/fnsapi/tmp_storage.rb
+++ b/lib/fnsapi/tmp_storage.rb
@@ -13,6 +13,7 @@ module Fnsapi
     end
 
     def token
+      @file.rewind
       data = JSON.parse(@file.read)
       expired_at = Time.parse(data['expire_at'])
 

--- a/spec/tmp_storage_spec.rb
+++ b/spec/tmp_storage_spec.rb
@@ -3,86 +3,107 @@
 RSpec.describe Fnsapi::TmpStorage do
   let(:instance) { described_class.new }
 
-  before { allow(File).to receive(:open).and_return(StubbedFile.new) }
-
-  it 'opens a file' do
-    instance
-    expect(File).to have_received(:open).once
-  end
-
-  context 'when Rails is not defined' do
-    it 'uses local tmp dir' do
-      instance
-      expect(File).to have_received(:open).with('tmp/fnsapi_tmp_credentials', 'a+')
-    end
-  end
-
-  context 'when Rails is defined' do
-    before do
-      class Rails; end
-
-      allow(Rails).to receive(:root).and_return(Pathname.new('/rails'))
-      allow_any_instance_of(Pathname).to receive(:join).and_return('/rails/tmp/fnsapi_tmp_credentials')
-    end
-
-    after { Object.send(:remove_const, :Rails) }
-
-    it 'creates file in Rails tmp dir' do
-      expect_any_instance_of(Pathname).to receive(:join).with('tmp', 'fnsapi_tmp_credentials')
-      instance
-      expect(File).to have_received(:open).with('/rails/tmp/fnsapi_tmp_credentials', 'a+')
-    end
-  end
-
-  describe '#write_token' do
-    subject(:write_token) { instance.write_token(token, expire_at) }
-    let(:token_string) { { token: token, expire_at: expire_at }.to_json }
-    let(:token) { 'token' }
-    let(:expire_at) { Time.now }
-
-    it 'clears file' do
-      expect_any_instance_of(StubbedFile).to receive(:truncate).with(0)
-      write_token
-    end
-
-    it 'writes new data in file' do
-      expect_any_instance_of(StubbedFile).to receive(:write).with(token_string)
-      write_token
-    end
-
-    it 'rewinds file' do
-      expect_any_instance_of(StubbedFile).to receive(:rewind)
-      write_token
-    end
-  end
-
-  describe '#token' do
-    before { allow_any_instance_of(StubbedFile).to receive(:read).and_return(token_string) }
-
+  describe 'with real file' do
     let(:token_string) { { token: token, expire_at: expire_at }.to_json }
     let(:token) { 'token' }
 
     context 'when not expired' do
       let(:expire_at) { DateTime.now + 100_000 }
+      before { instance.write_token(token, expire_at) }
 
       it 'returns token' do
         expect(instance.token).to eq('token')
       end
+
+      it 'return token if twice call' do
+        expect(instance.token).to eq('token')
+        expect(instance.token).to eq('token')
+      end
+    end
+  end
+
+  describe 'with stubbed file' do
+    before { allow(File).to receive(:open).and_return(StubbedFile.new) }
+
+    it 'opens a file' do
+      instance
+      expect(File).to have_received(:open).once
     end
 
-    context 'when expired' do
-      let(:expire_at) { DateTime.now - 100_000 }
-
-      it 'returns nil' do
-        expect(instance.token).to eq(nil)
+    context 'when Rails is not defined' do
+      it 'uses local tmp dir' do
+        instance
+        expect(File).to have_received(:open).with('tmp/fnsapi_tmp_credentials', 'a+')
       end
     end
 
-    context 'when JSON string invalid' do
-      let(:token_string) { '' }
+    context 'when Rails is defined' do
+      before do
+        class Rails; end
 
-      it 'returns nil' do
-        expect(instance.token).to eq(nil)
+        allow(Rails).to receive(:root).and_return(Pathname.new('/rails'))
+        allow_any_instance_of(Pathname).to receive(:join).and_return('/rails/tmp/fnsapi_tmp_credentials')
+      end
+
+      after { Object.send(:remove_const, :Rails) }
+
+      it 'creates file in Rails tmp dir' do
+        expect_any_instance_of(Pathname).to receive(:join).with('tmp', 'fnsapi_tmp_credentials')
+        instance
+        expect(File).to have_received(:open).with('/rails/tmp/fnsapi_tmp_credentials', 'a+')
+      end
+    end
+
+    describe '#write_token' do
+      subject(:write_token) { instance.write_token(token, expire_at) }
+      let(:token_string) { { token: token, expire_at: expire_at }.to_json }
+      let(:token) { 'token' }
+      let(:expire_at) { Time.now }
+
+      it 'clears file' do
+        expect_any_instance_of(StubbedFile).to receive(:truncate).with(0)
+        write_token
+      end
+
+      it 'writes new data in file' do
+        expect_any_instance_of(StubbedFile).to receive(:write).with(token_string)
+        write_token
+      end
+
+      it 'rewinds file' do
+        expect_any_instance_of(StubbedFile).to receive(:rewind)
+        write_token
+      end
+    end
+
+    describe '#token' do
+      before { allow_any_instance_of(StubbedFile).to receive(:read).and_return(token_string) }
+
+      let(:token_string) { { token: token, expire_at: expire_at }.to_json }
+      let(:token) { 'token' }
+
+      context 'when not expired' do
+        let(:expire_at) { DateTime.now + 100_000 }
+
+        it 'returns token' do
+          expect(instance.token).to eq('token')
+        end
+      end
+
+      context 'when expired' do
+        let(:expire_at) { DateTime.now - 100_000 }
+
+        it 'returns nil' do
+          expect(instance.token).to eq(nil)
+        end
+      end
+
+      context 'when JSON string invalid' do
+        let(:token_string) { '' }
+
+        it 'returns nil' do
+          expect(instance.token).to eq(nil)
+        end
       end
     end
   end


### PR DESCRIPTION
Если не добавить `rewind` перед чтением файла с токеном, то токен получается пустым и файл стирается. 
Добавил пример теста (с настоящим файлом), который воспроизводит эту ошибку. 